### PR TITLE
Prevent Clicks for Observing Players and Routes to LobbyWaitingRoom after Game completion

### DIFF
--- a/src/components/views/GameScreen.tsx
+++ b/src/components/views/GameScreen.tsx
@@ -153,7 +153,7 @@ const GameScreen = () => {
     if (game?.gameState === "FINISHED") {
       disconnectPlayer();
       stompClient.deactivate()
-      navigate("/lobbyOverview");
+      navigate(`/lobby/${game.gameId}`, { state: { lobby: {lobbyId : game.gameId}, scoreBoard : scoreBoard } });
     }
   }, [game]);
 

--- a/src/components/views/GameScreen.tsx
+++ b/src/components/views/GameScreen.tsx
@@ -140,13 +140,13 @@ const GameScreen = () => {
   function flip(card) {
     if(!yourTurn){
       toastNotify("Its not your turn so you cannot flip a card.", 2000)
-    }
+    } else {
     const data = JSON.stringify({ cardId: Number(card.cardId) });
     stompClient.publish({
       destination: `/app/games/${game.gameId}`,
       body: data,
     });
-  }
+  }}
 
 
   useEffect(() => {


### PR DESCRIPTION
* Minor change to prevent inactive players from making a move. 
  * While Server technically able to ignore the actions of inactive/observing players, but also good to prevent sending message in the first place.
* Rerouting users to lobbywaitingroom after game is finished. 
  * Currently buggy, immediately routing back to lobbyoverview as game goes from ONPLAY to FINISHED. 
  * Should ideally be OPEN after game ends and users go to lobbywaitingroom and new users are able to join. Need to coordinate this with backend