### PR TITLE
Full Lobby

### DIFF
--- a/src/components/views/GameScreen.tsx
+++ b/src/components/views/GameScreen.tsx
@@ -201,7 +201,9 @@ const GameScreen = () => {
     try {
       handleInactive();
       api.delete(`/games/${game.gameId}/player`)
-        .then(navigate("/lobbyoverview"));
+        .then(() => {
+          navigate("/lobbyoverview");
+        })
     } catch (error) {
       toastNotify("There was an error trying to leave the game. Please try again.", 1000, "warning");
     }


### PR DESCRIPTION
* fix bug where lobbyoverview is out of date when leaving an active game
* Was caused by race condition where navigate("/lobbyoverview") was executed before server removed player from lobby
* Wrapping navigate inside arrow func seems to solve this

fixes #88