### PR TITLE
Displaying score in scoreboard instead of rank

### DIFF
--- a/src/components/ui/UserStatWithIcon.tsx
+++ b/src/components/ui/UserStatWithIcon.tsx
@@ -13,7 +13,7 @@ export const UserStatWithIcon = (props) => {
   </span>
 
   <span className="button-label">{user.username}</span>
-  {props.currentStanding > 0 && ( // Check if currentStanding is larger than 0
+  {props.currentStanding > -1 && ( // Check if currentStanding is larger than 0
         <span className="notification-bubble">{props.currentStanding}</span>
       )}
   </span>);

--- a/src/components/views/GameScreen.tsx
+++ b/src/components/views/GameScreen.tsx
@@ -258,14 +258,14 @@ const GameScreen = () => {
                   {game.playerList.sort((a, b) => scoreBoard[a.userId].rank - scoreBoard[b.userId].rank).map((user) => (
                     <li key={user.userId} className="grid-item">
                       <div className="usr">
-                        <UserStatWithIcon user={user} currentStanding={scoreBoard[user.userId].rank} />
+                        <UserStatWithIcon user={user} currentStanding={scoreBoard[user.userId].score} />
                       </div>
                     </li>))}
                 </ul> : <ul className="grid-item">
                   <div className="h2-title">Current Players</div>
                   {game.playerList.map((user) => (<li key={user.userId} className="grid-item">
                     <div className="usr">
-                      <UserStatWithIcon user={user} currentStanding={1} />
+                      <UserStatWithIcon user={user} currentStanding={0} />
                     </div>
                   </li>))}
                 </ul>}

--- a/src/components/views/LobbyWaitingRoom.tsx
+++ b/src/components/views/LobbyWaitingRoom.tsx
@@ -229,7 +229,7 @@ const LobbyWaitingRoom = () => {
                   .map((user) => (<li key={user.userId} className="grid-item">
                     <UserStatWithIcon
                       user={user}
-                      currentStanding={scoreBoard[user.userId]?.rank ?? 0 /* Default value */}
+                      currentStanding={scoreBoard[user.userId]?.score ?? 0 /* Default value */}
                     />
                   </li>))}
               </ul>)}


### PR DESCRIPTION
Fixes bug #109 by showing the points in the scoreboard instead of the rank. 

While the rank is no longer explicitly shown as a number, the scoreboard is always sorted in the order of the rank, which is why I think this implementation is fine. 

Let me know what you guys think:
@niklasschm1dt 
@EliasWJMuller 
@hs-kim1990 
@NicSchuler 